### PR TITLE
Added random java.time.LocalDate generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,12 @@
     <groupId>com.fyodor</groupId>
     <artifactId>fyodor</artifactId>
     <version>1.0-SNAPSHOT</version>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
-            <version>4.10</version>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -21,16 +22,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>17.0</version>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/src/main/java/com/fyodor/generators/DefaultRandomValues.java
+++ b/src/main/java/com/fyodor/generators/DefaultRandomValues.java
@@ -1,0 +1,30 @@
+package com.fyodor.generators;
+
+import java.util.Random;
+
+final class DefaultRandomValues implements RandomValues {
+
+    private final Random random;
+
+    DefaultRandomValues(final Random random) {
+        this.random = random;
+    }
+
+    @Override
+    public long randomLong(final long lower, final long upper) {
+        if (lower == upper) {
+            return lower;
+        }
+
+        return randomLong(upper - lower + 1) + lower;
+    }
+
+    private long randomLong(final long max) {
+        long bits, val;
+        do {
+            bits = (random.nextLong() << 1) >>> 1;
+            val = bits % max;
+        } while (bits - val + (max - 1) < 0L);
+        return val;
+    }
+}

--- a/src/main/java/com/fyodor/generators/LocalDateGenerator.java
+++ b/src/main/java/com/fyodor/generators/LocalDateGenerator.java
@@ -1,0 +1,51 @@
+package com.fyodor.generators;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+
+import java.time.LocalDate;
+
+final class LocalDateGenerator implements Generator<LocalDate> {
+
+    private static final LocalDate DEFAULT_UPPER_BOUND = LocalDate.of(2999, 12, 31);
+    private static final LocalDate DEFAULT_LOWER_BOUND = LocalDate.of(0, 1, 1);
+
+    private final RandomValues randomValues;
+    private final Range<LocalDate> range;
+
+    public LocalDateGenerator(final RandomValues randomValues, final Range<LocalDate> range) {
+        this.randomValues = randomValues;
+        this.range = range;
+    }
+
+    @Override
+    public LocalDate next() {
+        final long lowerBound = lowerBound().toEpochDay();
+        final long upperBound = upperBound().toEpochDay();
+        return LocalDate.ofEpochDay(randomValues.randomLong(lowerBound, upperBound));
+    }
+
+    private LocalDate lowerBound() {
+        if (!range.hasLowerBound()) {
+            return DEFAULT_LOWER_BOUND;
+        }
+
+        final LocalDate lowerEndpoint = range.lowerEndpoint();
+
+        return range.lowerBoundType() == BoundType.CLOSED
+                ? lowerEndpoint
+                : lowerEndpoint.plusDays(1);
+    }
+
+    private LocalDate upperBound() {
+        if (!range.hasUpperBound()) {
+            return DEFAULT_UPPER_BOUND;
+        }
+
+        final LocalDate upperEndpoint = range.upperEndpoint();
+
+        return range.upperBoundType() == BoundType.CLOSED
+                ? upperEndpoint
+                : upperEndpoint.minusDays(1);
+    }
+}

--- a/src/main/java/com/fyodor/generators/RDG.java
+++ b/src/main/java/com/fyodor/generators/RDG.java
@@ -3,6 +3,7 @@ package com.fyodor.generators;
 import com.fyodor.generators.characters.CharacterFilter;
 import com.google.common.collect.Range;
 
+import java.time.LocalDate;
 import java.util.Random;
 
 public class RDG {
@@ -26,5 +27,9 @@ public class RDG {
 
     public static Generator<Integer> integer(Range<Integer> range) {
         return new IntegerGenerator(range);
+    }
+
+    public static Generator<LocalDate> localDate(final Range<LocalDate> range) {
+        return new LocalDateGenerator(new DefaultRandomValues(random), range);
     }
 }

--- a/src/main/java/com/fyodor/generators/RandomValues.java
+++ b/src/main/java/com/fyodor/generators/RandomValues.java
@@ -1,0 +1,5 @@
+package com.fyodor.generators;
+
+interface RandomValues {
+    long randomLong(long min, long max);
+}

--- a/src/test/java/com/fyodor/generators/LocalDateGeneratorTest.java
+++ b/src/test/java/com/fyodor/generators/LocalDateGeneratorTest.java
@@ -1,0 +1,96 @@
+package com.fyodor.generators;
+
+import com.google.common.collect.Range;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static com.fyodor.generators.Sampler.from;
+import static com.google.common.collect.Range.*;
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class LocalDateGeneratorTest {
+
+    private final int sampleSize = 1000;
+
+    @Test
+    public void neverReturnsNull() {
+        final Generator<LocalDate> generator = RDG.localDate(Range.all());
+        assertThat(from(generator).sample(10000))
+                .doesNotContainNull();
+    }
+
+    @Test
+    public void closedRangeWhereLowerAndUpperBoundsAreBothTheSameShouldReturnTheSameDateEveryTime() {
+        assertThat(from(RDG.localDate(closed(now(), now()))).sample(sampleSize).unique())
+                .containsOnly(now());
+
+        assertThat(from(RDG.localDate(closed(LocalDate.MIN, LocalDate.MIN))).sample(sampleSize).unique())
+                .containsOnly(LocalDate.MIN);
+
+        assertThat(from(RDG.localDate(closed(LocalDate.MAX, LocalDate.MAX))).sample(sampleSize).unique())
+                .containsOnly(LocalDate.MAX);
+    }
+
+    @Test
+    public void closedRangeWithOneSingleDayBetweenLowerBoundAndUpperBoundShouldReturnBothBounds() {
+        assertThat(from(RDG.localDate(closed(LocalDate.MIN, LocalDate.MIN.plusDays(1)))).sample(sampleSize).unique())
+                .containsOnly(LocalDate.MIN, LocalDate.MIN.plusDays(1));
+
+        assertThat(from(RDG.localDate(closed(LocalDate.MAX.minusDays(1), LocalDate.MAX))).sample(sampleSize).unique())
+                .containsOnly(LocalDate.MAX.minusDays(1), LocalDate.MAX);
+    }
+
+    @Test
+    public void openRangeSpanningThreeDaysShouldReturnMiddleDateOnly() {
+        final Generator<LocalDate> generator = RDG.localDate(open(now().minusDays(1), now().plusDays(1)));
+        assertThat(from(generator).sample(sampleSize).unique()).containsOnly(now());
+    }
+
+    @Test
+    public void openClosedRangeSpanningThreeDaysShouldReturnMiddleAndLatestDateOnly() {
+        final Generator<LocalDate> generator = RDG.localDate(openClosed(now().minusDays(1), now().plusDays(1)));
+        assertThat(from(generator).sample(sampleSize).unique())
+                .containsOnly(now(), now().plusDays(1));
+    }
+
+    @Test
+    public void closedOpenRangeSpanningThreeDaysShouldReturnEarliestAndMiddleDateOnly() {
+        final Generator<LocalDate> generator = RDG.localDate(closedOpen(now().minusDays(1), now().plusDays(1)));
+        assertThat(from(generator).sample(sampleSize).unique())
+                .containsOnly(now().minusDays(1), now());
+    }
+
+    @Test
+    public void greaterThanRangeOneDayBeforeDefaultUpperBoundReturnsOnlyTheDefaultUpperBound() {
+        final LocalDate defaultUpperBound = LocalDate.of(2999, 12, 31);
+        final Generator<LocalDate> generator = RDG.localDate(greaterThan(defaultUpperBound.minusDays(1)));
+        assertThat(from(generator).sample(sampleSize).unique())
+                .containsOnly(defaultUpperBound);
+    }
+
+    @Test
+    public void lessThanRangeOneDayAfterDefaultLowerBoundReturnsOnlyTheDefaultLowerBound() {
+        final LocalDate defaultLowerBound = LocalDate.of(0, 1, 1);
+        final Generator<LocalDate> generator = RDG.localDate(lessThan(defaultLowerBound.plusDays(1)));
+        assertThat(from(generator).sample(sampleSize).unique())
+                .containsOnly(defaultLowerBound);
+    }
+
+    @Test
+    public void atMostRangeForDefaultLowerBoundReturnsOnlyTheDefaultLowerBound() {
+        final LocalDate defaultLowerBound = LocalDate.of(0, 1, 1);
+        final Generator<LocalDate> generator = RDG.localDate(atMost(defaultLowerBound));
+        assertThat(from(generator).sample(sampleSize).unique())
+                .containsOnly(defaultLowerBound);
+    }
+
+    @Test
+    public void atLeastRangeForDefaultUpperBoundReturnsOnlyTheDefaultUpperBound() {
+        final LocalDate defaultUpperBound = LocalDate.of(2999, 12, 31);
+        final Generator<LocalDate> generator = RDG.localDate(atLeast(defaultUpperBound));
+        assertThat(from(generator).sample(sampleSize).unique())
+                .containsOnly(defaultUpperBound);
+    }
+}

--- a/src/test/java/com/fyodor/generators/Sampler.java
+++ b/src/test/java/com/fyodor/generators/Sampler.java
@@ -1,0 +1,46 @@
+package com.fyodor.generators;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+final class Sampler<T> {
+
+    private final Generator<? extends T> generatorOfT;
+
+    private Sampler(final Generator<? extends T> generatorOfT) {
+        this.generatorOfT = generatorOfT;
+    }
+
+    public Sample<T> sample(final int sampleSize) {
+        return new Sample(Stream.generate(generatorOfT::next)
+                .limit(sampleSize)
+                .collect(Collectors.toList()));
+    }
+
+    public static <T> Sampler<T> from(final Generator<? extends T> generatorOfT) {
+        return new Sampler<>(generatorOfT);
+    }
+
+    static final class Sample<T> implements Iterable<T> {
+
+        private final List<T> listOfT;
+
+        Sample(final List<T> listOfT) {
+            this.listOfT = listOfT;
+        }
+
+        Set<T> unique() {
+            return newHashSet(listOfT);
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return listOfT.iterator();
+        }
+    }
+}


### PR DESCRIPTION
Added RandomValues and DefaultRandomValues as a wrapper over java.util.Random and any other class that may help provide random values. Currently only provides random longs within a specified range. Should be given to Generator implementations.

Removed apache commons

Upgraded to junit 4.11
