### PR TITLE
Fix #3 added a default string generator

### DIFF
--- a/fyodor-core/src/main/java/uk/org/fyodor/generators/RDG.java
+++ b/fyodor-core/src/main/java/uk/org/fyodor/generators/RDG.java
@@ -117,6 +117,10 @@ public class RDG {
         return new StringGenerator(max);
     }
 
+    public static Generator<String> string() {
+        return new StringGenerator(30);
+    }
+
     public static Generator<String> string(Integer max, String charset) {
         return new StringGenerator(max, charset);
     }


### PR DESCRIPTION
Theres a quick fix for a default string generator, written in the same style as the integer one. 

The other option is to return the static default, instead of a new instance, not sure what, if any benefit there is to this, besides the 'default' being set in one place. 
